### PR TITLE
Fix the path in the go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module magento2-static-deploy
+module github.com/elgentos/magento2-static-deploy
 
 go 1.21


### PR DESCRIPTION
Modfied the path to github.com/elgentos/..., so the tool can be installed directly. Closes #2 .