### PR TITLE
Improve deployment times and diskspace usage by using symlinks

### DIFF
--- a/main.go
+++ b/main.go
@@ -305,7 +305,7 @@ func deployStatic(magentoRoot string, locales, themes, areas []string, numJobs i
 	}
 
 	// Ensure both minified and unminified versions of CSS/JS files exist
-	ensureMinifiedCounterparts(magentoRoot, results, verbose)
+	ensureMinifiedCounterparts(magentoRoot, results, verbose, useSymlink)
 
 	// Compile LESS files (email CSS) after file copying is complete
 	compileLessForResults(magentoRoot, results, verbose)
@@ -325,13 +325,13 @@ func deployStatic(magentoRoot string, locales, themes, areas []string, numJobs i
 // ensureMinifiedCounterparts walks each deployed directory and ensures that both
 // minified (.min.js/.min.css) and unminified versions exist for every CSS/JS file.
 // Magento's RequireJS resolver expects both to be present depending on store config.
-func ensureMinifiedCounterparts(magentoRoot string, results []DeployResult, verbose bool) {
+func ensureMinifiedCounterparts(magentoRoot string, results []DeployResult, verbose bool, useSymlink bool) {
 	if verbose {
 		fmt.Printf("\nEnsuring minified/unminified counterparts...\n")
 	}
 
 	for _, result := range results {
-		if result.Error != "" {
+		if result.Error != "" || result.Symlinked {
 			continue
 		}
 
@@ -349,32 +349,32 @@ func ensureMinifiedCounterparts(magentoRoot string, results []DeployResult, verb
 			// .min.js exists but .js counterpart does not
 			case strings.HasSuffix(name, ".min.js"):
 				counterpart := strings.TrimSuffix(path, ".min.js") + ".js"
-				if _, err := os.Stat(counterpart); os.IsNotExist(err) {
-					if copyFile(path, counterpart) == nil {
+				if _, err := os.Lstat(counterpart); os.IsNotExist(err) {
+					if placeFile(path, counterpart, useSymlink) == nil {
 						created++
 					}
 				}
 			// .js exists but .min.js counterpart does not
 			case strings.HasSuffix(name, ".js"):
 				counterpart := strings.TrimSuffix(path, ".js") + ".min.js"
-				if _, err := os.Stat(counterpart); os.IsNotExist(err) {
-					if copyFile(path, counterpart) == nil {
+				if _, err := os.Lstat(counterpart); os.IsNotExist(err) {
+					if placeFile(path, counterpart, useSymlink) == nil {
 						created++
 					}
 				}
 			// .min.css exists but .css counterpart does not
 			case strings.HasSuffix(name, ".min.css"):
 				counterpart := strings.TrimSuffix(path, ".min.css") + ".css"
-				if _, err := os.Stat(counterpart); os.IsNotExist(err) {
-					if copyFile(path, counterpart) == nil {
+				if _, err := os.Lstat(counterpart); os.IsNotExist(err) {
+					if placeFile(path, counterpart, useSymlink) == nil {
 						created++
 					}
 				}
 			// .css exists but .min.css counterpart does not
 			case strings.HasSuffix(name, ".css"):
 				counterpart := strings.TrimSuffix(path, ".css") + ".min.css"
-				if _, err := os.Stat(counterpart); os.IsNotExist(err) {
-					if copyFile(path, counterpart) == nil {
+				if _, err := os.Lstat(counterpart); os.IsNotExist(err) {
+					if placeFile(path, counterpart, useSymlink) == nil {
 						created++
 					}
 				}
@@ -1328,4 +1328,3 @@ func shouldSkipFile(relPath string) bool {
 
 	return false
 }
-

--- a/watcher.go
+++ b/watcher.go
@@ -45,11 +45,11 @@ func (w *FileWatcher) Start() {
 				if w.hasChanges() {
 					fmt.Println("Changes detected. Running deployment...")
 					version := fmt.Sprintf("%d", time.Now().Unix())
-					fileCount, err := deployTheme(w.root, DeployJob{
-						Locale: "nl_NL",
-						Theme:  "Vendor/Hyva",
-						Area:   "frontend",
-					}, version)
+				fileCount, err := deployTheme(w.root, DeployJob{
+					Locale: "nl_NL",
+					Theme:  "Vendor/Hyva",
+					Area:   "frontend",
+				}, version, false)
 					if err != nil {
 						fmt.Printf("Error during deployment: %v\n", err)
 					} else {


### PR DESCRIPTION
Since this tool doesn't actually change any files as part of the static deployment process it's possible to forgo the copying of the files entirely and instead generate a relative symlink to the original location of the deplyment file on the disk. This saves in the amount of diskspace required to deploy the file.

Because we use relative symlinks:
``` underscore.js -> ../../../../../../lib/web/underscore.js ```
it's still possible to build the static content in one enviroment and copy it to another environment without the built process breaking (as long as both environments support symlinks, of course).

For customers with a lot of different locales we can take this a step further. When you use the locale option only one locale will be fully built using this symlinks approach and every other locale will just be a symlink to the original locale.

This further improves built times and filesizes for stores with a lot of locales. In our testing, on a store with 24 active locales build times went from taking about 30 seconds to build to taking 1.5 seconds to build. Most of that time was in only having to build the email less once. But the actually copying of the files also went from about 7.2 seconds to 0.2 seconds.

Filesizes shrunk from 2,9 GB to +- 400 MB.